### PR TITLE
Log priority of gcm pushes

### DIFF
--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -324,12 +324,13 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
                     log.info(
                         (
                             "Sent GCM push for "
-                            "userID=%s, appID=%s, eventID=%s, gcmMessageId=%s"
+                            "userID=%s, appID=%s, eventID=%s, gcmMessageId=%s, priority=%s"
                         ),
                         n.user_id if device else None,
                         device.app_id if device else None,
                         event_id,
                         message_id,
+                        "normal" if n.prio == "low" else "high"
                     )
 
             return failed, new_pushkeys


### PR DESCRIPTION
The client can specify a priority, so let's log that so we have one spot where we can understand what was pushed.